### PR TITLE
Fix hotbarRight not being implemented and improve Oculus Touch keybindings

### DIFF
--- a/mcxr-play/src/main/java/net/sorenon/mcxr/play/input/XrInput.java
+++ b/mcxr-play/src/main/java/net/sorenon/mcxr/play/input/XrInput.java
@@ -165,7 +165,7 @@ public final class XrInput {
             if (Minecraft.getInstance().player != null)
                 Minecraft.getInstance().player.getInventory().swapPaint(1);
         }
-        if (actionSet.hotbarLeft.currentState && actionSet.hotbarLeft.changedSinceLastSync) {
+        if (actionSet.hotbarRight.currentState && actionSet.hotbarRight.changedSinceLastSync) {
             if (Minecraft.getInstance().player != null)
                 Minecraft.getInstance().player.getInventory().swapPaint(-1);
         }

--- a/mcxr-play/src/main/java/net/sorenon/mcxr/play/input/actionsets/VanillaGameplayActionSet.java
+++ b/mcxr-play/src/main/java/net/sorenon/mcxr/play/input/actionsets/VanillaGameplayActionSet.java
@@ -74,14 +74,15 @@ public class VanillaGameplayActionSet extends ActionSet {
                         new Pair<>(use, "/user/hand/left/input/trigger/value"),
                         new Pair<>(attack, "/user/hand/right/input/trigger/value"),
                         new Pair<>(move, "/user/hand/left/input/thumbstick"),
-                        new Pair<>(hotbar, "/user/hand/right/input/thumbstick/y"),
                         new Pair<>(turn, "/user/hand/right/input/thumbstick/x"),
                         new Pair<>(inventory, "/user/hand/left/input/y/click"),
                         new Pair<>(jump, "/user/hand/right/input/a/click"),
-                        new Pair<>(sprint, "/user/hand/right/input/squeeze/value"),
-                        new Pair<>(sneak, "/user/hand/left/input/squeeze/value"),
+                        new Pair<>(hotbarRight, "/user/hand/right/input/squeeze/value"),
+                        new Pair<>(hotbarLeft, "/user/hand/left/input/squeeze/value"),
                         new Pair<>(resetPos, "/user/hand/right/input/thumbstick/click"),
-                        new Pair<>(teleport, "/user/hand/right/input/b/click")
+                        new Pair<>(teleport, "/user/hand/right/input/b/click"),
+                        new Pair<>(sprint, "/user/hand/left/input/thumbstick/click"),
+                        new Pair<>(sneak, "/user/hand/right/input/thumbstick")
                 )
         );
         map.computeIfAbsent("/interaction_profiles/valve/index_controller", aLong -> new ArrayList<>()).addAll(


### PR DESCRIPTION
This is similar to #28 , however after testing it, #28 didnt work as intended. Due to a typo in VanillaGameplayActionSet.java, acitonSet.hotbarRight was never checked. This PR fixes that, as well as offering the same bindings as #28 (minus the menu button, which did not work)

The bindings changed are as follows:
Left thumbstick pressed is now sprint
Right thumbstick pressed is now crouch
Grips on either controller now move the selected hotbar slot in the respective direction.

I playtested for about an hour with these keybinds, and they work significantly better than the existing ones.