### PR TITLE
Make it more difficult to accidently sneak using index controllers.

### DIFF
--- a/mcxr-play/src/main/java/net/sorenon/mcxr/play/input/actionsets/VanillaGameplayActionSet.java
+++ b/mcxr-play/src/main/java/net/sorenon/mcxr/play/input/actionsets/VanillaGameplayActionSet.java
@@ -79,7 +79,7 @@ public class VanillaGameplayActionSet extends ActionSet {
                         new Pair<>(inventory, "/user/hand/left/input/y/click"),
                         new Pair<>(jump, "/user/hand/right/input/a/click"),
                         new Pair<>(sprint, "/user/hand/right/input/squeeze/value"),
-                        new Pair<>(sneak, "/user/hand/left/input/squeeze/value"),
+                        new Pair<>(sneak, "/user/hand/left/input/squeeze/"),
                         new Pair<>(resetPos, "/user/hand/right/input/thumbstick/click"),
                         new Pair<>(teleport, "/user/hand/right/input/b/click")
                 )
@@ -94,7 +94,7 @@ public class VanillaGameplayActionSet extends ActionSet {
                         new Pair<>(inventory, "/user/hand/left/input/b/click"),
                         new Pair<>(jump, "/user/hand/right/input/a/click"),
                         new Pair<>(sprint, "/user/hand/right/input/squeeze/value"),
-                        new Pair<>(sneak, "/user/hand/left/input/squeeze/value"),
+                        new Pair<>(sneak, "/user/hand/left/input/squeeze/force"),
                         new Pair<>(resetPos, "/user/hand/right/input/thumbstick/click"),
                         new Pair<>(teleport, "/user/hand/right/input/b/click")
                 )


### PR DESCRIPTION
When playing with sneak set to input/squeeze/value, just touching your fingers to the base of the index controller makes you sneak.
This is super annoying for riding horses, as you end up dismounting at the lightest touch.